### PR TITLE
Improve pilreg flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,24 @@ $ pilreg
 Usage:
   pilreg <registry> [flags]
 
-Flags:
-  -c, --cache string     Path to cache image layers (optional, only used if images are pulled)
-  -h, --help             help for pilreg
-  -i, --insecure         Fetch Data over plaintext
-  -r, --repos strings    list of repositories to scan on the registry. If blank, pilreg will attempt to enumerate them using the catalog API
-  -o, --results string   Path to directory for storing results. If blank, outputs configs and manifests as json object to Stdout.(must be used if 'store-images` is enabled)
-  -k, --skip-tls         Disables TLS certificate verification
+Registry config options:
+  -r, --repos strings   list of repositories to scan on the registry. If blank, pilreg will attempt to enumerate them using the catalog API
+  -t, --tags strings    list of tags to scan on each repository. If blank, pilreg will attempt to enumerate them using the tags API
+
+Storage config options:
+  -o, --results string   Path to directory for storing results. If blank, outputs configs and manifests as json object to Stdout.(must be used if 'store-images' is enabled)
   -s, --store-images     Downloads filesystem for discovered images and stores an archive in the output directory (Disabled by default, requires --results to be set)
-  -t, --tags strings     list of tags to scan on each repository. If blank, pilreg will attempt to enumerate them using the tags API
-  -x, --trufflehog       Integrate with Trufflehog to scan the images once they are found
-  -w, --workers int      Number of workers when pulling images. If set too high, this may cause errors. (optional, only used if images are pulled) (default 8)
+  -c, --cache string     Path to cache image layers (optional, only used if images are pulled)
+  -w, --whiteout         Include whiteout files when saving filesystem archive
+
+Analysis config options:
+  -x, --trufflehog   Integrate with Trufflehog to scan the images once they are found
+
+Connection options:
+  -k, --skip-tls      Disables TLS certificate verification
+  -i, --insecure      Fetch Data over plaintext
+      --workers int   Number of workers when pulling images. If set too high, this may cause errors. (optional, only used if images are pulled) (default 8)
+      --version       Print version and exit
 ```
 
 ## Example:

--- a/cmd/pilreg/main.go
+++ b/cmd/pilreg/main.go
@@ -12,7 +12,9 @@ import (
 	"github.com/remeh/sizedwaitgroup"
 
 	"github.com/antitree/go-pillage-registries/pkg/pillage"
+	"github.com/antitree/go-pillage-registries/pkg/version"
 	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 )
 
 var (
@@ -26,20 +28,74 @@ var (
 	resultsPath string
 	workerCount int
 	truffleHog  bool
+	whiteout    bool
+	versionFlag bool
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringSliceVarP(&repos, "repos", "r", []string{}, "list of repositories to scan on the registry. If blank, pilreg will attempt to enumerate them using the catalog API")
-	rootCmd.PersistentFlags().StringSliceVarP(&tags, "tags", "t", []string{}, "list of tags to scan on each repository. If blank, pilreg will attempt to enumerate them using the tags API")
+	rootCmd.Version = version.Get()
 
-	rootCmd.PersistentFlags().StringVarP(&resultsPath, "results", "o", "", "Path to directory for storing results. If blank, outputs configs and manifests as json object to Stdout.(must be used if 'store-images` is enabled)")
-	rootCmd.PersistentFlags().BoolVarP(&skiptls, "skip-tls", "k", false, "Disables TLS certificate verification")
-	rootCmd.PersistentFlags().BoolVarP(&insecure, "insecure", "i", false, "Fetch Data over plaintext")
-	rootCmd.PersistentFlags().BoolVarP(&storeImages, "store-images", "s", false, "Downloads filesystem for discovered images and stores an archive in the output directory (Disabled by default, requires --results to be set)")
-	rootCmd.PersistentFlags().StringVarP(&cachePath, "cache", "c", "", "Path to cache image layers (optional, only used if images are pulled)")
-	rootCmd.PersistentFlags().IntVarP(&workerCount, "workers", "w", 8, "Number of workers when pulling images. If set too high, this may cause errors. (optional, only used if images are pulled)")
-	rootCmd.PersistentFlags().BoolVarP(&truffleHog, "trufflehog", "x", false, "Integrate with Trufflehog to scan the images once they are found")
-	// rootCmd.PersistentFlags().StringVar(&bruteForceConfigFile, "config", "", "Path to brute force config JSON file (optional)")
+	rootCmd.Flags().SortFlags = false
+
+	// Registry config options
+	registryFlags := flag.NewFlagSet("registry", flag.ExitOnError)
+	registryFlags.SortFlags = false
+	registryFlags.StringSliceVarP(&repos, "repos", "r", []string{}, "list of repositories to scan on the registry. If blank, pilreg will attempt to enumerate them using the catalog API")
+	registryFlags.StringSliceVarP(&tags, "tags", "t", []string{}, "list of tags to scan on each repository. If blank, pilreg will attempt to enumerate them using the tags API")
+	rootCmd.PersistentFlags().AddFlagSet(registryFlags)
+
+	// Storage config options
+	storageFlags := flag.NewFlagSet("storage", flag.ExitOnError)
+	storageFlags.SortFlags = false
+	storageFlags.StringVarP(&resultsPath, "results", "o", "", "Path to directory for storing results. If blank, outputs configs and manifests as json object to Stdout.(must be used if 'store-images' is enabled)")
+	storageFlags.BoolVarP(&storeImages, "store-images", "s", false, "Downloads filesystem for discovered images and stores an archive in the output directory (Disabled by default, requires --results to be set)")
+	storageFlags.StringVarP(&cachePath, "cache", "c", "", "Path to cache image layers (optional, only used if images are pulled)")
+	storageFlags.BoolVarP(&whiteout, "whiteout", "w", false, "Include whiteout files when saving filesystem archive")
+	rootCmd.PersistentFlags().AddFlagSet(storageFlags)
+
+	// Analysis config options
+	analysisFlags := flag.NewFlagSet("analysis", flag.ExitOnError)
+	analysisFlags.SortFlags = false
+	analysisFlags.BoolVarP(&truffleHog, "trufflehog", "x", false, "Integrate with Trufflehog to scan the images once they are found")
+	rootCmd.PersistentFlags().AddFlagSet(analysisFlags)
+
+	// Connection options
+	connectionFlags := flag.NewFlagSet("connection", flag.ExitOnError)
+	connectionFlags.SortFlags = false
+	connectionFlags.BoolVarP(&skiptls, "skip-tls", "k", false, "Disables TLS certificate verification")
+	connectionFlags.BoolVarP(&insecure, "insecure", "i", false, "Fetch Data over plaintext")
+	connectionFlags.IntVar(&workerCount, "workers", 8, "Number of workers when pulling images. If set too high, this may cause errors. (optional, only used if images are pulled)")
+	connectionFlags.BoolVar(&versionFlag, "version", false, "Print version and exit")
+	rootCmd.PersistentFlags().AddFlagSet(connectionFlags)
+
+	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		fmt.Fprintln(cmd.OutOrStdout(), cmd.Short)
+		fmt.Fprintln(cmd.OutOrStdout())
+		fmt.Fprintf(cmd.OutOrStdout(), "Usage:\n  %s\n\n", cmd.UseLine())
+
+		if registryFlags.HasAvailableFlags() {
+			fmt.Fprintln(cmd.OutOrStdout(), "Registry config options:")
+			fmt.Fprint(cmd.OutOrStdout(), registryFlags.FlagUsages())
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+
+		if storageFlags.HasAvailableFlags() {
+			fmt.Fprintln(cmd.OutOrStdout(), "Storage config options:")
+			fmt.Fprint(cmd.OutOrStdout(), storageFlags.FlagUsages())
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+
+		if analysisFlags.HasAvailableFlags() {
+			fmt.Fprintln(cmd.OutOrStdout(), "Analysis config options:")
+			fmt.Fprint(cmd.OutOrStdout(), analysisFlags.FlagUsages())
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+
+		if connectionFlags.HasAvailableFlags() {
+			fmt.Fprintln(cmd.OutOrStdout(), "Connection options:")
+			fmt.Fprint(cmd.OutOrStdout(), connectionFlags.FlagUsages())
+		}
+	})
 }
 
 var rootCmd = &cobra.Command{
@@ -50,6 +106,10 @@ var rootCmd = &cobra.Command{
 }
 
 func run(_ *cobra.Command, registries []string) {
+	if versionFlag {
+		fmt.Println(version.Get())
+		return
+	}
 	if skiptls {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
@@ -64,6 +124,7 @@ func run(_ *cobra.Command, registries []string) {
 		CachePath:    cachePath,
 		ResultsPath:  resultsPath,
 		CraneOptions: craneoptions,
+		Whiteout:     whiteout,
 	}
 
 	images := pillage.EnumRegistries(registries, repos, tags, craneoptions...)

--- a/cmd/pilreg/main_test.go
+++ b/cmd/pilreg/main_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestHelpOutputGroups(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"--help"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("help command failed: %v", err)
+	}
+	out := buf.String()
+	checks := []string{
+		"Registry config options:",
+		"Storage config options:",
+		"Analysis config options:",
+		"Connection options:",
+	}
+	for _, s := range checks {
+		if !strings.Contains(out, s) {
+			t.Errorf("expected help to contain %q", s)
+		}
+	}
+}

--- a/pkg/pillage/pillage.go
+++ b/pkg/pillage/pillage.go
@@ -35,6 +35,7 @@ type StorageOptions struct {
 	ResultsPath  string
 	StoreImages  bool
 	CraneOptions []crane.Option
+	Whiteout     bool
 }
 
 // Store a default brute force config file

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+var (
+	// Version is set via build flags
+	Version string = "dev"
+	// BuildDate represents the build timestamp
+	BuildDate string = "unknown"
+)
+
+// Get returns the formatted version string
+func Get() string {
+	return Version + " (" + BuildDate + ")"
+}


### PR DESCRIPTION
## Summary
- group command line flags by category: registry, storage, analysis, and connection
- add whiteout flag and move workers flag to long form
- add version flag using new version package
- display grouped help output
- update README
- test help formatting

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_686932cbda74832c96ba40b63ce23ec9