### PR TITLE
Improve CLI flag grouping and version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Flags:
   -k, --skip-tls         Disables TLS certificate verification
   -s, --store-images     Downloads filesystem for discovered images and stores an archive in the output directory (Disabled by default, requires --results to be set)
   -t, --tags strings     list of tags to scan on each repository. If blank, pilreg will attempt to enumerate them using the tags API
-  -x, --trufflehog       Integrate with Trufflehog to scan the images once they are found
-  -w, --workers int      Number of workers when pulling images. If set too high, this may cause errors. (optional, only used if images are pulled) (default 8)
+  -w, --whiteout         Look for deleted/whiteout files in image layers
+      --workers int      Number of workers when pulling images. If set too high, this may cause errors. (optional, only used if images are pulled) (default 8)
+      --version          Print version information and exit
 ```
 
 ## Example:

--- a/tests/func/test.sh
+++ b/tests/func/test.sh
@@ -5,12 +5,12 @@ BIN=pilreg
 REG="localhost:5000"
 
 tests=(
-  "-s -r skaffold -o ./tmp/test1 -0"
+  "-s -r skaffold -o ./tmp/test1 -w"
   "-r skaffold -o ./tmp/test2 -x"
-  "-r skaffold -0"
+  "-r skaffold -w"
   "-r skaffold -c /tmp/cache"
   "-r skaffold"
-  "-s -r keys -o ./tmp/test6 -0"  # New test for the keys image
+  "-s -r keys -o ./tmp/test6 -w"  # New test for the keys image
 )
 
 cleanup() {


### PR DESCRIPTION
## Summary
- organize flags into functional groups
- add `--version` flag and version variables
- rename whiteout flag to `-w` and move workers to `--workers`
- update custom help output
- adjust functional test script and docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686935284ef0832c8ff1a683a7886a7c