### PR TITLE
Add local tarball scan option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Flags:
   -k, --skip-tls         Disables TLS certificate verification
   -s, --store-images     Downloads filesystem for discovered images and stores an archive in the output directory (Disabled by default, requires --results to be set)
   -t, --tags strings     list of tags to scan on each repository. If blank, pilreg will attempt to enumerate them using the tags API
+  -l, --local string     Path to a local image tarball to scan
   -w, --whiteout         Look for deleted/whiteout files in image layers
       --workers int      Number of workers when pulling images. If set too high, this may cause errors. (optional, only used if images are pulled) (default 8)
       --version          Print version information and exit


### PR DESCRIPTION
## Summary
- support scanning Docker image tarballs via `--local` CLI option
- validate that supplied file is a tar archive
- document new option in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68693937c9f8832c94ea582edb06cc63