### PR TITLE
Add automatic local mode for tarball arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Usage:
   --workers	Number of concurrent workers.
   --version	Print version information and exit.
 ```
+If `--local` is not provided and the value for `<registry>` ends with a common tarball extension such as `.tar`, `.tar.gz`, or `.tgz`, `pilreg` will automatically switch to local mode and scan that file.
 
 ## Example:
 

--- a/cmd/pilreg/main.go
+++ b/cmd/pilreg/main.go
@@ -120,6 +120,10 @@ func run(cmd *cobra.Command, registries []string) {
 		fmt.Printf("pilreg %s (%s)\n", version, buildDate)
 		return
 	}
+	if localTar == "" && len(registries) > 0 && isTarballPath(registries[0]) {
+		localTar = registries[0]
+		registries = registries[1:]
+	}
 	if len(registries) == 0 && localTar == "" {
 		cmd.Help()
 		return
@@ -226,6 +230,17 @@ func printFlags(cmd *cobra.Command, names []string) {
 func contains(slice []string, item string) bool {
 	for _, s := range slice {
 		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+func isTarballPath(path string) bool {
+	tarExts := []string{".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz"}
+	lower := strings.ToLower(path)
+	for _, ext := range tarExts {
+		if strings.HasSuffix(lower, ext) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
- assume `--local` mode if no `-l` flag is set and the `<registry>` argument looks like a tarball
- document this implicit behaviour in the README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68695baa6ffc832caa8e56927364af6a