### PR TITLE
Add Makefile and extend functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+BIN=pilreg
+
+.PHONY: build install run test
+
+build:
+	go build -o $(BIN) ./cmd/pilreg
+
+install:
+	go install ./cmd/pilreg
+
+run:
+	go run ./cmd/pilreg $(ARGS)
+
+test: build
+	go test ./...
+	bash tests/func/test_setup.sh
+	bash tests/func/test.sh

--- a/cmd/pilreg/main.go
+++ b/cmd/pilreg/main.go
@@ -201,9 +201,9 @@ func CheckTrufflehogInstalled() bool {
 func init() {
 	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		fmt.Print("Usage: pilreg [OPTIONS] <registry>\n\n")
-		fmt.Println("pilreg is penetration testing tool targeting container images hosted in a registry or in a tar ball.\n")
+		fmt.Println("pilreg is penetration testing tool targeting container images hosted in a registry or in a tar ball.")
 
-		fmt.Println("Examples:\n")
+		fmt.Println("Examples:")
 		fmt.Println("  pilreg 127.0.0.1:5000 -a")
 		fmt.Println("  pilreg 127.0.0.1:5000 --repos nginx --tags latest,stable")
 		fmt.Println("  pilreg gcr.io --repos <project>/<my image>:latest")

--- a/tests/func/test.sh
+++ b/tests/func/test.sh
@@ -11,6 +11,7 @@ tests=(
   "-r skaffold -c /tmp/cache"
   "-r skaffold"
   "-s -r keys -o ./tmp/test6 -w"  # New test for the keys image
+  "--local example/keys.tar -o ./tmp/test7 -w"  # Test local tarball scanning
 )
 
 cleanup() {
@@ -34,6 +35,12 @@ for i in "${!tests[@]}"; do
   find "$out_dir" > "$before"
 
   if $BIN "$REG" ${tests[$i]} > "$out_dir/stdout.log" ; then
+    status=0
+  else
+    status=$?
+  fi
+
+  if [ $status -eq 0 ] && grep -q "Reference" "$out_dir/stdout.log"; then
     result="PASS"
   else
     result="FAIL"

--- a/tests/func/test_setup.sh
+++ b/tests/func/test_setup.sh
@@ -53,6 +53,12 @@ docker push ${KEYS_IMAGE} || {
     exit 1
 }
 
+echo "Saving keys image to example/keys.tar for local tests..."
+docker save ${KEYS_IMAGE} -o example/keys.tar || {
+    echo "Failed to save keys image tarball"
+    exit 1
+}
+
 echo "Setup complete. Images available:"
 echo "  ${LOCAL_IMAGE}"
 echo "  ${KEYS_IMAGE}"


### PR DESCRIPTION
## Summary
- add Makefile with build/install/run/test targets
- fix help output formatting in `pilreg`
- expand functional test setup to export a tarball
- add local tarball test and simple output verification

## Testing
- `make test` *(fails: Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695fcc8fc8832cb13d5fadee41600c