### PR TITLE
Enable configurable debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Usage:
   --insecure	Use HTTP instead of HTTPS.
   --workers	Number of concurrent workers.
   --version	Print version information and exit.
+  --debug       Enable debug logging.
 ```
 If `--local` is not provided and the value for `<registry>` ends with a common tarball extension such as `.tar`, `.tar.gz`, or `.tgz`, `pilreg` will automatically switch to local mode and scan that file.
 

--- a/cmd/pilreg/main.go
+++ b/cmd/pilreg/main.go
@@ -117,6 +117,7 @@ func NormalizeFlags() {
 }
 
 func run(cmd *cobra.Command, registries []string) {
+	pillage.SetDebug(debug)
 	if showVersion {
 		fmt.Printf("pilreg %s (%s)\n", version, buildDate)
 		return

--- a/pkg/pillage/logutil.go
+++ b/pkg/pillage/logutil.go
@@ -4,6 +4,13 @@ import (
 	"log"
 )
 
+var debugEnabled bool
+
+// SetDebug enables or disables debug logging.
+func SetDebug(enabled bool) {
+	debugEnabled = enabled
+}
+
 const (
 	colorReset  = "\033[0m"
 	colorRed    = "\033[31m"
@@ -21,8 +28,9 @@ func LogWarn(format string, args ...interface{}) {
 }
 
 func LogDebug(format string, args ...interface{}) {
-	// Only log debug messages if debug mode is enabled
-	// This allows for more verbose output during development or troubleshooting
+	if !debugEnabled {
+		return
+	}
 	log.Printf(colorGray+"[DEBUG] "+format+colorReset, args...)
 }
 


### PR DESCRIPTION
## Summary
- add `SetDebug` to logutil and gate `LogDebug` on the new flag
- enable debug mode based on `--debug` CLI flag
- document the `--debug` option in the README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686964baebd0832cac9c8dc40f61dc19