### PR TITLE
Add registry token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Usage:
  Connection options:
   --skip-tls	Disable TLS verification.
   --insecure	Use HTTP instead of HTTPS.
-  --workers	Number of concurrent workers.
+  --token       Bearer token or password for registry auth.
+  --username    Username for token auth.
+  --workers     Number of concurrent workers.
   --version	Print version information and exit.
   --debug       Enable debug logging.
 ```

--- a/pkg/pillage/pillage.go
+++ b/pkg/pillage/pillage.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -69,9 +70,12 @@ type FileVersion struct {
 	Data  []byte
 }
 
-func MakeCraneOptions(insecure bool) (options []crane.Option) {
+func MakeCraneOptions(insecure bool, auth authn.Authenticator) (options []crane.Option) {
 	if insecure {
 		options = append(options, crane.Insecure)
+	}
+	if auth != nil {
+		options = append(options, crane.WithAuth(auth))
 	}
 	return options
 }

--- a/pkg/pillage/pillage_test.go
+++ b/pkg/pillage/pillage_test.go
@@ -21,7 +21,7 @@ func TestMakeCraneOptions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotOptions := MakeCraneOptions(tt.args.insecure); !reflect.DeepEqual(gotOptions, tt.wantOptions) {
+			if gotOptions := MakeCraneOptions(tt.args.insecure, nil); !reflect.DeepEqual(gotOptions, tt.wantOptions) {
 				t.Errorf("MakeCraneOptions() = %v, want %v", gotOptions, tt.wantOptions)
 			}
 		})


### PR DESCRIPTION
## Summary
- add new `--token` and `--username` flags
- let `MakeCraneOptions` accept an authenticator
- use the authenticator when a token is provided
- document authentication flags

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68696d9f1960832c9a68b86d796026f3