### PR TITLE
Add whiteout filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Examples:
   pilreg 127.0.0.1:5000 --repos nginx --tags latest,stable
   pilreg <registry> --repos <project>/<my image>:latest
   pilreg --local <path/to/tarball.tar> --whiteout
-  pilreg --local <path/to/tarball.tar> --whiteout-filter
+  pilreg --local <path/to/tarball.tar> --whiteout-filter=apk,tmp,test
   pilreg 
   pilreg <registry> --trufflehog
 
@@ -45,7 +45,7 @@ Examples:
  Analysis config options:
   --trufflehog	Scan image contents with TruffleHog.
   --whiteout	Look for deleted/whiteout files in image layers.
-  --whiteout-filter     Filter common temporary files when extracting whiteouts.
+  --whiteout-filter     Filter patterns when extracting whiteouts. Defaults to 'tmp,cache,apk,apt'.
 
  Connection options:
   --skip-tls	Disable TLS verification.

--- a/cmd/pilreg/main.go
+++ b/cmd/pilreg/main.go
@@ -32,7 +32,7 @@ var (
 	workerCount    int
 	truffleHog     bool
 	whiteOut       bool
-	whiteOutFilter bool
+	whiteOutFilter []string
 	filterSmall    int64
 	showVersion    bool
 	debug          bool
@@ -65,7 +65,8 @@ func init() {
 	analysisFlags := pflag.NewFlagSet("Analysis Options", pflag.ContinueOnError)
 	analysisFlags.BoolVarP(&truffleHog, "trufflehog", "x", false, "Scan image contents with TruffleHog.")
 	analysisFlags.BoolVarP(&whiteOut, "whiteout", "w", false, "Look for deleted/whiteout files in image layers.")
-	analysisFlags.BoolVar(&whiteOutFilter, "whiteout-filter", false, "Filter common temporary files when extracting whiteouts.")
+	analysisFlags.StringSliceVar(&whiteOutFilter, "whiteout-filter", nil, "Filter patterns when extracting whiteouts. Defaults to 'tmp,cache,apk,apt'.")
+	analysisFlags.Lookup("whiteout-filter").NoOptDefVal = "tmp,cache,apk,apt"
 	analysisFlags.BoolVarP(&all, "all", "a", true, "Enable all analysis options by default. (Very noisy!)")
 
 	rootCmd.PersistentFlags().AddFlagSet(analysisFlags)
@@ -98,7 +99,7 @@ func NormalizeFlags() {
 	if truffleHog && !storeImages {
 		storeImages = true
 	}
-	if whiteOutFilter {
+	if len(whiteOutFilter) > 0 {
 		whiteOut = true
 	}
 
@@ -235,7 +236,7 @@ func init() {
 		fmt.Println("  pilreg <registry> --repos test/nginx:latest")
 		fmt.Println("  pilreg ghcr.io --repos <gh username>/<repo>/<package/image> --username --token <PAT> -a")
 		fmt.Println("  pilreg --local <path/to/tarball.tar> --whiteout")
-		fmt.Println("  pilreg --local <path/to/tarball.tar> --whiteout-filter")
+		fmt.Println("  pilreg --local <path/to/tarball.tar> --whiteout-filter=apk,tmp,test")
 		fmt.Println("  pilreg <registry> --trufflehog")
 
 		fmt.Println("\n Registry/Local config options:")

--- a/pkg/pillage/pillage.go
+++ b/pkg/pillage/pillage.go
@@ -54,7 +54,7 @@ type StorageOptions struct {
 	FilterSmall    int64
 	StoreTarballs  bool
 	WhiteOut       bool
-	WhiteOutFilter bool
+	WhiteOutFilter []string
 }
 
 //go:embed default_config.json
@@ -89,13 +89,12 @@ func securejoin(paths ...string) (out string) {
 }
 
 func shouldFilterWhiteout(name string, options *StorageOptions) bool {
-	if !options.WhiteOutFilter {
+	if len(options.WhiteOutFilter) == 0 {
 		return false
 	}
 	lower := strings.ToLower(name)
-	filters := []string{"tmp", "cache", "apk", "apt"}
-	for _, f := range filters {
-		if strings.Contains(lower, f) {
+	for _, f := range options.WhiteOutFilter {
+		if strings.Contains(lower, strings.ToLower(f)) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
- add `--whiteout-filter` CLI option
- enable whiteout automatically when filter is used
- skip restoring files containing `tmp`, `cache`, `apk`, or `apt`
- document the new option in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6872d0f4867c832ca2c62c34a4f6d5e9