### PR TITLE
Add scan deduplication by image digest

### DIFF
--- a/pkg/pillage/pillage_test.go
+++ b/pkg/pillage/pillage_test.go
@@ -168,6 +168,23 @@ func TestImageData_Store(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "skip when history exists",
+			image: &ImageData{
+				Reference:  "dummy.io/test/image:latest",
+				Registry:   "dummy.io",
+				Repository: "test/image",
+				Tag:        "latest",
+				Digest:     "sha256:deadbeef",
+			},
+			options: func() *StorageOptions {
+				opt := &StorageOptions{CachePath: t.TempDir(), OutputPath: t.TempDir(), StoreImages: true}
+				os.MkdirAll(filepath.Join(opt.OutputPath, "results"), 0755)
+				os.WriteFile(filepath.Join(opt.OutputPath, "results", "deadbeef"), []byte("history"), 0644)
+				return opt
+			}(),
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- track image digest when enumerating images
- skip scanning if a history file for that digest already exists
- record history information after scanning
- test the skip behaviour

## Testing
- `go test ./...`
- `make test` *(fails: Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b1c1c8f68832cb688aeb3f9c57c70