### PR TITLE
Skip scanning previously processed images

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Examples:
 ```
 If `--local` is not provided and the value for `<registry>` ends with a common tarball extension such as `.tar`, `.tar.gz`, or `.tgz`, `pilreg` will automatically switch to local mode and scan that file.
 
+When pilreg completes a scan it saves the Docker image history in a file named with the image's sha256 digest under `<output>/results/`. If this file is found on a subsequent run, the image is skipped and not scanned again.
+
 ## Example:
 
 In the [example directory](example/) there is an example of an image which

--- a/pkg/pillage/pillage_test.go
+++ b/pkg/pillage/pillage_test.go
@@ -168,6 +168,28 @@ func TestImageData_Store(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "skip when digest file exists",
+			image: &ImageData{
+				Reference:  "dummy.io/test/image:latest",
+				Registry:   "dummy.io",
+				Repository: "test/image",
+				Tag:        "latest",
+				Digest:     "sha256:deadbeef",
+				Manifest:   `{}`,
+			},
+			options: func() *StorageOptions {
+				out := &StorageOptions{
+					CachePath:   t.TempDir(),
+					OutputPath:  t.TempDir(),
+					StoreImages: true,
+				}
+				os.MkdirAll(filepath.Join(out.OutputPath, "results"), 0755)
+				os.WriteFile(filepath.Join(out.OutputPath, "results", "sha256_deadbeef"), []byte("hist"), 0644)
+				return out
+			}(),
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- avoid rescanning images by checking for a digest history file
- record image digest and save docker history under `results/`
- document the new behaviour
- add unit test for skipping logic

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687b1c1c8f68832cb688aeb3f9c57c70