### PR TITLE
Add scan hash index to skip rescanning images

### DIFF
--- a/pkg/pillage/hashindex.go
+++ b/pkg/pillage/hashindex.go
@@ -1,0 +1,69 @@
+package pillage
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"sync"
+)
+
+// HashIndex keeps track of image hashes that have already been scanned.
+type HashIndex struct {
+	path string
+	mu   sync.Mutex
+	set  map[string]struct{}
+}
+
+// NewHashIndex loads or creates a hash index at the given path.
+func NewHashIndex(path string) (*HashIndex, error) {
+	hi := &HashIndex{path: path, set: make(map[string]struct{})}
+	// Ensure file exists
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDONLY, 0666)
+	if err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		hi.set[scanner.Text()] = struct{}{}
+	}
+	f.Close()
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return hi, nil
+}
+
+// Exists returns true if the hash is already recorded.
+func (h *HashIndex) Exists(hash string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, ok := h.set[hash]
+	return ok
+}
+
+// Add records the given hash if it isn't already stored.
+func (h *HashIndex) Add(hash string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.set[hash]; ok {
+		return nil
+	}
+	f, err := os.OpenFile(h.path, os.O_APPEND|os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	if _, err := f.WriteString(hash + "\n"); err != nil {
+		f.Close()
+		return err
+	}
+	f.Close()
+	h.set[hash] = struct{}{}
+	return nil
+}
+
+// ImageHash returns the SHA256 of the image's manifest.
+func ImageHash(img *ImageData) string {
+	sum := sha256.Sum256([]byte(img.Manifest))
+	return hex.EncodeToString(sum[:])
+}


### PR DESCRIPTION
## Summary
- introduce `HashIndex` to record scanned image hashes safely
- compute image hash from manifest and skip images whose hash already exists
- store hashes in `scanned_shas.log`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687b241ec528832c8232850b55642e3e