### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - name: Verify build
+        run: |
+          go build ./...
+          go test ./...
+
+      - name: Build binaries
+        run: |
+          mkdir dist
+          for GOOS in linux darwin windows; do
+            for GOARCH in amd64; do
+              BIN="pilreg-$GOOS-$GOARCH"
+              EXT=""
+              if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
+              GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build -o "$BIN$EXT" ./cmd/pilreg
+              tar -czvf "dist/$BIN.tar.gz" "$BIN$EXT"
+              rm "$BIN$EXT"
+            done
+          done
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- build & test before releasing
- compile binaries for common OS/arch combinations
- upload tarballs to GitHub releases triggered by semver tag

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687b2d750c58832c82e1641354bf581f