### PR TITLE
Enhance whiteout filter to skip empty files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Examples:
   --trufflehog	Scan image contents with TruffleHog.
   --whiteout	Look for deleted/whiteout files in image layers.
   --whiteout-filter     Filter patterns when extracting whiteouts. Defaults to 'tmp,cache,apk,apt'.
+                        Files that are empty regular files are also skipped.
 
  Connection options:
   --skip-tls	Disable TLS verification.


### PR DESCRIPTION
## Summary
- extend `FileVersion` to store `TypeFlag`
- ignore empty regular files when restoring whiteout deletions
- document new behavior in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687b2e436238832c82b8766bea12075f