### PR TITLE
Add pre-commit hooks and golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - govet
+    - staticcheck
+    - errcheck
+    - gofmt
+    - goimports
+    - ineffassign
+    - unused
+  disable:
+    - gochecknoglobals
+
+issues:
+  exclude-use-default: false
+  exclude:
+    # allow unchecked Close/Write error where appropriate
+    - "Error return value.*(Close|Write).*(is not checked)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+- repo: https://github.com/pre-commit/mirrors-gofmt
+  rev: v1
+  hooks:
+  - id: gofmt
+    args: ["-s", "-l", "-w"]
+
+- repo: https://github.com/pre-commit/mirrors-goimports
+  rev: v0.1.5
+  hooks:
+  - id: goimports
+    args: ["-local", "github.com/antitree/go-pillage-registries"]
+
+- repo: https://github.com/pre-commit/mirrors-golangci-lint
+  rev: v1.54.2
+  hooks:
+  - id: golangci-lint
+    args: ["run", "--timeout=5m"]

--- a/README.md
+++ b/README.md
@@ -107,6 +107,34 @@ pilreg --autocomplete powershell > pilreg.ps1
 In the [examples directory](docs/examples/) there is a demo Dockerfile that builds an image
 with hidden (whiteout) secrets for testing the `--whiteout` feature.
 
+## Developer Setup
+
+This project uses pre-commit hooks to enforce Go formatting, import grouping, and linting.
+To enable these checks locally, first install the [pre-commit](https://pre-commit.com/) framework:
+
+```bash
+pip install pre-commit
+```
+
+Then install the Git hook scripts:
+
+```bash
+pre-commit install
+```
+
+To run all checks against all files (e.g. after first install):
+
+```bash
+pre-commit run --all-files
+```
+
+The configured hooks include:
+- `gofmt` (with simplification via `-s`)
+- `goimports` (organizes and groups imports according to the module path)
+- `golangci-lint` (runs govet, staticcheck, errcheck, ineffassign, unused, and more)
+
+These checks are also executed in CI to ensure consistent code quality.
+
 ## Acknowledgments
 * Thanks to @jmakinen-ncc the original author of NCC Group's go-registry-pillage
 * @jonjohnsonjr: For the idea around the whiteout file feature (and writing Crane)

--- a/pkg/pillage/logutil.go
+++ b/pkg/pillage/logutil.go
@@ -19,14 +19,17 @@ const (
 	colorGray   = "\033[90m"
 )
 
+// LogInfo logs informational messages prefixed with [INFO].
 func LogInfo(format string, args ...interface{}) {
 	log.Printf(colorBlue+"[INFO] "+format+colorReset, args...)
 }
 
+// LogWarn logs warning messages prefixed with [WARN].
 func LogWarn(format string, args ...interface{}) {
 	log.Printf(colorYellow+"[WARN] "+format+colorReset, args...)
 }
 
+// LogDebug logs debug messages prefixed with [DEBUG] when debug is enabled.
 func LogDebug(format string, args ...interface{}) {
 	if !debugEnabled {
 		return
@@ -34,6 +37,7 @@ func LogDebug(format string, args ...interface{}) {
 	log.Printf(colorGray+"[DEBUG] "+format+colorReset, args...)
 }
 
+// LogError logs error messages prefixed with [ERROR].
 func LogError(format string, args ...interface{}) {
 	log.Printf(colorRed+"[ERROR] "+format+colorReset, args...)
 }


### PR DESCRIPTION
This adds pre-commit hooks for gofmt, goimports, and golangci-lint (configured via .pre-commit-config.yaml and .golangci.yml), and updates README with developer setup instructions.